### PR TITLE
Fixes #34, adds proper data transfer support

### DIFF
--- a/ferus.nimble
+++ b/ferus.nimble
@@ -31,3 +31,6 @@ else:
   requires "windy >= 0.0.0"
 
 requires "netty >= 0.2.1"
+
+requires "curly >= 1.1.1"
+requires "webby >= 0.2.1"

--- a/flake.nix
+++ b/flake.nix
@@ -36,6 +36,7 @@
               libseccomp
               libGL
               glfw
+              curl.dev
 
               xorg.libX11
               openssl.dev
@@ -47,6 +48,7 @@
             LD_LIBRARY_PATH = with pkgs; lib.makeLibraryPath [
               libGL
               simdutf
+              curl.dev
             ];
 
             env = {

--- a/nim.cfg
+++ b/nim.cfg
@@ -12,6 +12,7 @@
 # -d:ferusAddMangohudToRendererPrefix
 # -d:ferusJustWaitForConnection
 -d:ferusUseGlfw
+-d:ferusUseCurl
 # -d:ferusIpcLogSendsToStdout
 
 # glfw flags

--- a/src/components/layout/processor.nim
+++ b/src/components/layout/processor.nim
@@ -1,7 +1,7 @@
 ## Layout processor
 ## Copyright (C) 2024 Trayambak Rai and Ferus Authors
 
-import std/[strutils, tables, logging, options]
+import std/[strutils, tables, logging, options, base64]
 import vmath, bumpy, pixie, pixie/fonts
 import ./box
 import ../parsers/html/document
@@ -106,7 +106,7 @@ proc addText*(layout: var Layout, text: string, fontSize: float32, kind: BoxKind
       width = layout.getWordLength(word) + 4
       height = layout.getWordHeight(word) + 4
 
-    echo "place " & word.repr & " at " & $layout.cursor
+    # echo "place " & word.repr & " at " & $layout.cursor
 
     layout.boxes &=
       TextBox(
@@ -226,8 +226,8 @@ proc constructFromElem*(layout: var Layout, elem: HTMLElement) =
     )
     
     if *image:
-      info (&image).data
-      layout.addImage((&image).data)
+      let content = decode((&image).data)
+      layout.addImage(content)
   of TAG_SCRIPT: discard
   else:
     warn "layout: unhandled tag: " & $elem.tag

--- a/src/components/network/ipc.nim
+++ b/src/components/network/ipc.nim
@@ -1,4 +1,5 @@
-import std/options
+import std/[base64, options]
+import ../../components/shared/[sugar]
 import sanchar/parse/url, sanchar/proto/http/shared, ferus_ipc/shared
 
 type
@@ -7,5 +8,11 @@ type
     url*: URL
 
   NetworkFetchResult* = ref object
-    kind: FerusMagic = feNetworkSendResult
+    kind*: FerusMagic = feNetworkSendResult
     response*: Option[HTTPResponse]
+
+func content*(res: NetworkFetchResult): string {.inline.} =
+  if !res.response:
+    return
+
+  (&res.response).content.decode()

--- a/src/components/network/process.nim
+++ b/src/components/network/process.nim
@@ -1,6 +1,6 @@
-import std/[strutils, logging, options, json]
+import std/[strutils, logging, options, json, net]
 import sanchar/[http, proto/http/shared], sanchar/parse/url, ferus_ipc/client/prelude, jsony
-import ../../components/shared/sugar
+import ../../components/shared/[nix, sugar]
 import ../../components/network/ipc
 import ../../components/build_utils
 
@@ -46,6 +46,13 @@ proc networkFetch*(
   client.setState(Idling)
 
 proc talk(client: var IPCClient, process: FerusProcess) {.inline.} =
+  var count: cint
+
+  discard nix.ioctl(client.socket.getFd().cint, nix.FIONREAD, addr count)
+
+  if count < 1:
+    return
+
   let
     data = client.receive()
     jdata = tryParseJson(data, JsonNode)

--- a/src/components/parsers/html/document.nim
+++ b/src/components/parsers/html/document.nim
@@ -1,6 +1,7 @@
 ## I love chame
 
 import std/[options, logging, tables, base64]
+import sanchar/parse/url
 import ../../shared/sugar
 import ../../web/dom
 import pretty
@@ -16,6 +17,7 @@ type
 
   HTMLDocument* = ref object
     elems*: seq[HTMLElement]
+    url*: URL
 
 iterator items*(elem: HTMLElement): HTMLElement =
   for child in elem.children:

--- a/src/components/parsers/html/process.nim
+++ b/src/components/parsers/html/process.nim
@@ -25,7 +25,7 @@ proc htmlParse*(
   info "Parsed HTML in " & $(endTime - startTime)
  
   HTMLParseResult(
-    document: some(document.parseHTMLDocument()) # I love chame
+    document: some(document.parseHTMLDocument())
   )
 
 proc talk(client: var IPCClient, process: FerusProcess) {.inline.} =

--- a/src/ferus.nim
+++ b/src/ferus.nim
@@ -33,16 +33,16 @@ proc main() {.inline.} =
   var content: string
 
   if resource.startsWith("https://") or resource.startsWith("http://"):
-    let data = master.fetchNetworkResource(0, paramStr(1))
+    let data = master.fetchNetworkResource(0, resource)
+    master.urls.add(resource)
 
     if not *data:
       error "Failed to fetch HTTP resource"
       quit(1)
 
-    let resp = &(&data).response # i love unwrapping
-    print(resp)
+    let resp = &data
 
-    content = resp.content
+    content = resp.content()
   else:
     if not fileExists(resource):
       error "Failed to find file"


### PR DESCRIPTION
- **(fix) components/network: don't stall when there are no messages**
- **(xxx) flake: add `curl`**
- **(feat) add support for `curl`**
- **(xxx) update src/components/layout/processor.nim**
- **(fix) components/master: fix `fetchNetworkResource`'s algorithm**
- **(fix) components/network/ipc: add proper helper methods**
- **(xxx) components/network: improve decoding support**
- **(add) components/parsers/html: add `url` field to document**

This PR adds support for the networking process to use cURL instead of Sanchar, as it is not very mature as of right now and hangs up on certain sites. \
It fixes a few other things and fixes data transfer requests, meaning the renderer process can display images properly.
