### PR TITLE
Implement `window.open()`

### DIFF
--- a/src/components/js/process.nim
+++ b/src/components/js/process.nim
@@ -33,7 +33,7 @@ proc jsExecBuffer*(js: var JSProcess, data: string) =
 
   js.parser = newParser(data.buffer.decode())
   js.runtime = newRuntime(data.name.decode(), js.parser.parse())
-  window.generateIR(js.runtime)
+  window.generateIR(js.runtime, js.ipc)
   jsdoc.generateIR(js.runtime)
   jswebsocket.generateBindings(js.runtime, js.ipc)
   jsdoc.updateDocumentState(js.runtime, js.document)

--- a/src/components/master/master.nim
+++ b/src/components/master/master.nim
@@ -448,7 +448,8 @@ proc packetHandler*(
   of feRendererGotoURL:
     let data = tryParseJson(data, RendererGotoURL)
 
-    if process.kind != Renderer:
+    if process.kind notin {Renderer, JSRuntime}:
+      # TODO: separate magic code for jsruntime
       master.server.reportBadMessage(
         process, "Non-renderer process attempted to use `feRendererGotoURL`!", High
       )

--- a/src/components/web/window.nim
+++ b/src/components/web/window.nim
@@ -1,6 +1,8 @@
 import std/[logging, tables]
-import bali/runtime/prelude
+import bali/runtime/prelude, bali/internal/sugar
 import ../../components/build_utils
+import ../../components/ipc/client/prelude
+import ../../components/renderer/ipc
 import pretty
 
 type
@@ -13,7 +15,7 @@ type
 
   JSWindow* = object
 
-proc generateIR*(runtime: Runtime) =
+proc generateIR*(runtime: Runtime, ipc: var IPCClient) =
   debug "components/web/window: generating interfaces"
   runtime.registerType("navigator", JSNavigator)
   runtime.setProperty(JSNavigator, "appCodeName", str("Mozilla"))
@@ -22,4 +24,14 @@ proc generateIR*(runtime: Runtime) =
   runtime.setProperty(JSNavigator, "buildId", str("20181001000000"))
   runtime.setProperty(
     JSNavigator, "oscpu", str(hostOS & ' ' & getArchitectureUAString())
+  )
+
+  var pIpc = addr(ipc)
+  runtime.registerType("window", JSWindow)
+  runtime.defineFn(
+    JSWindow,
+    "open",
+    proc() =
+      let url = runtime.ToString(&runtime.argument(1, required = true))
+      pIpc[].send(RendererGotoURL(url: url)),
   )


### PR DESCRIPTION
This is a veeery naive implementation. It doesn't implement your regular
popup blocking safety nets (like the mandatory interaction prior to a
successful open call) but it does work.
